### PR TITLE
Add changelog on the existing project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* General Tarantool definitions.
+* Partial builtin `box` module definitions.
+* Partial builtin `box.backup` submodule definitions.
+* Partial builtin `box.cfg` submodule definitions.
+* Partial builtin `box.error` submodule definitions.
+* Partial builtin `box.index` submodule definitions.
+* Partial builtin `box.schema` submodule definitions.
+* Partial builtin `box.session` submodule definitions.
+* Partial builtin `box.slab` submodule definitions.
+* Partial builtin `box.space` submodule definitions.
+* Partial builtin `box.schema` submodule definitions.
+* Partial builtin `box.stat` submodule definitions.
+* Partial builtin `box.tuple` submodule definitions.
+* Builtin `clock` module definitions.
+* Builtin `console` module definitions.
+* Partial builtin `config` module definitions.
+* Builtin `datetime` module definition.
+* Builtin `decimal` module definition.
+* Builtin `fiber` module definitions.
+* Builtin `fio` module definitions.
+* Builtin `iconv` module definitions.
+* Builtin `jit` module definitions.
+* Builtin `json` module definitions.
+* Builtin `net.box` module definitions.
+* Builtin `string` module definitions.
+* Builtin `uri` module definitions.
+* Builtin `uuid` module definitions.
+* Builtin `yaml` module definitions.


### PR DESCRIPTION
This patch adds a basic changelog on the project. It follows keepachangelog [^1] format. It's going to be used for the release notes.

[^1] https://keepachangelog.com/