### PR TITLE
Add builtin `strict` and `errno` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Builtin `buffer` module definitions.
+* Builtin `errno` module definitions.
 
 ## [0.1.0] - 12.04.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Builtin `buffer` module definitions.
 * Builtin `errno` module definitions.
+* Builtin `strict` module definitions.
 
 ## [0.1.0] - 12.04.25
 

--- a/Library/errno.lua
+++ b/Library/errno.lua
@@ -1,0 +1,96 @@
+---@meta
+
+---# Builtin `errno` module.
+---
+---The errno module is typically used within a function or within a Lua program, in association with a module whose functions can return operating-system errors, such as [fio](lua://fio).
+---
+---@class errno: table
+---@field E2BIG integer Argument list too long (POSIX.1-2001).
+---@field EACCES integer Permission denied (POSIX.1-2001).
+---@field EADDRINUSE integer Address already in use (POSIX.1-2001).
+---@field EADDRNOTAVAIL integer Address not available (POSIX.1-2001).
+---@field EAFNOSUPPORT integer Address family not supported (POSIX.1-2001).
+---@field EAGAIN integer Resource temporarily unavailable (may be the same value as EWOULDBLOCK) (POSIX.1-2001).
+---@field EALREADY integer Connection already in progress (POSIX.1-2001).
+---@field EBADF integer Bad file descriptor (POSIX.1-2001).
+---@field EBADMSG integer Bad message (POSIX.1-2001).
+---@field EBUSY integer Device or resource busy (POSIX.1-2001).
+---@field ECANCELED integer Operation canceled (POSIX.1-2001).
+---@field ECHILD integer No child processes (POSIX.1-2001).
+---@field ECONNABORTED integer Connection aborted (POSIX.1-2001).
+---@field ECONNREFUSED integer Connection refused (POSIX.1-2001).
+---@field ECONNRESET integer Connection reset (POSIX.1-2001).
+---@field EDEADLK integer Resource deadlock avoided (POSIX.1-2001).
+---@field EDESTADDRREQ integer Destination address required (POSIX.1-2001).
+---@field EDOM integer Mathematics argument out of domain of function (POSIX.1, C99).
+---@field EDQUOT integer Disk quota exceeded (POSIX.1-2001).
+---@field EEXIST integer File exists (POSIX.1-2001).
+---@field EFAULT integer Bad address (POSIX.1-2001).
+---@field EFBIG integer File too large (POSIX.1-2001).
+---@field EHOSTUNREACH integer Host is unreachable (POSIX.1-2001).
+---@field EIDRM integer Identifier removed (POSIX.1-2001).
+---@field EILSEQ integer Invalid or incomplete multibyte or wide character (POSIX.1, C99).
+---@field EINPROGRESS integer Operation in progress (POSIX.1-2001).
+---@field EINTR integer Interrupted function call (POSIX.1-2001); see signal(7).
+---@field EINVAL integer Invalid argument (POSIX.1-2001).
+---@field EIO integer Input/output error (POSIX.1-2001).
+---@field EISCONN integer Socket is connected (POSIX.1-2001).
+---@field EISDIR integer Is a directory (POSIX.1-2001).
+---@field ELOOP integer Too many levels of symbolic links (POSIX.1-2001).
+---@field EMFILE integer Too many open files (POSIX.1-2001).  Commonly caused by exceeding the RLIMIT_NOFILE resource limit described in getrlimit(2).  Can also be caused by exceeding the limit specified in /proc/sys/fs/nr_open.
+---@field EMLINK integer Too many links (POSIX.1-2001).
+---@field EMSGSIZE integer Message too long (POSIX.1-2001).
+---@field EMULTIHOP integer Multihop attempted (POSIX.1-2001).
+---@field ENAMETOOLONG integer Filename too long (POSIX.1-2001).
+---@field ENETDOWN integer Network is down (POSIX.1-2001).
+---@field ENETRESET integer Connection aborted by network (POSIX.1-2001).
+---@field ENETUNREACH integer Network unreachable (POSIX.1-2001).
+---@field ENFILE integer Too many open files in system (POSIX.1-2001).  On Linux, this is probably a result of encountering the /proc/sys/fs/file-max limit (see proc(5)).
+---@field ENOBUFS integer No buffer space available (POSIX.1 (XSI STREAMS option)).
+---@field ENODATA integer The named attribute does not exist, or the process has no access to this attribute; see xattr(7).
+---@field ENODEV integer No such device (POSIX.1-2001).
+---@field ENOENT integer No such file or directory (POSIX.1-2001).
+---@field ENOEXEC integer Exec format error (POSIX.1-2001).
+---@field ENOLCK integer No locks available (POSIX.1-2001).
+---@field ENOLINK integer Link has been severed (POSIX.1-2001).
+---@field ENOMEM integer Not enough space/cannot allocate memory (POSIX.1-2001).
+---@field ENOMSG integer No message of the desired type (POSIX.1-2001).
+---@field ENOPROTOOPT integer Protocol not available (POSIX.1-2001).
+---@field ENOSPC integer No space left on device (POSIX.1-2001).
+---@field ENOSR integer No STREAM resources (POSIX.1 (XSI STREAMS option)).
+---@field ENOSTR integer Not a STREAM (POSIX.1 (XSI STREAMS option)).
+---@field ENOSYS integer Function not implemented (POSIX.1-2001).
+---@field ENOTCONN integer The socket is not connected (POSIX.1-2001).
+---@field ENOTDIR integer Not a directory (POSIX.1-2001).
+---@field ENOTEMPTY integer Directory not empty (POSIX.1-2001).
+---@field ENOTSOCK integer Not a socket (POSIX.1-2001).
+---@field ENOTSUP integer Operation not supported (POSIX.1-2001).
+---@field ENOTTY integer Inappropriate I/O control operation (POSIX.1-2001).
+---@field ENXIO integer No such device or address (POSIX.1-2001).
+---@field EOPNOTSUPP integer Operation not supported on socket (POSIX.1-2001).
+---@field EOVERFLOW integer Value too large to be stored in data type (POSIX.1-2001).
+---@field EPERM integer Operation not permitted (POSIX.1-2001).
+---@field EPIPE integer Broken pipe (POSIX.1-2001).
+---@field EPROTO integer Protocol error (POSIX.1-2001).
+---@field EPROTONOSUPPORT integer Protocol not supported (POSIX.1-2001).
+---@field EPROTOTYPE integer Protocol wrong type for socket (POSIX.1-2001).
+---@field ERANGE integer Result too large (POSIX.1, C99).
+---@field EROFS integer Read-only filesystem (POSIX.1-2001).
+---@field ESPIPE integer Invalid seek (POSIX.1-2001).
+---@field ESRCH integer No such process (POSIX.1-2001).
+---@field ESTALE integer Stale file handle (POSIX.1-2001).
+---@field ETIME integer Timer expired (POSIX.1 (XSI STREAMS option)).
+---@field ETIMEDOUT integer Connection timed out (POSIX.1-2001).
+---@field ETXTBSY integer Text file busy (POSIX.1-2001).
+---@field EWOULDBLOCK integer Operation would block (may be same value as EAGAIN) (POSIX.1-2001).
+---@field EXDEV integer Improper link (POSIX.1-2001).
+---@overload fun(): integer
+local errno = {}
+
+---Return a string, given an error number.
+---
+---@param code integer?
+---@return string
+function errno.strerror(code) end
+
+return errno

--- a/Library/strict.lua
+++ b/Library/strict.lua
@@ -1,0 +1,16 @@
+---@meta
+
+---# Builtin `strict` module
+---
+---The strict module has functions for turning "strict mode" on or off. When strict mode is on, an attempt to use an undeclared global variable will cause an error. A global variable is considered “undeclared” if it has never had a value assigned to it. Often this is an indication of a programming error.
+---
+---By default strict mode is off, unless tarantool was built with the -DCMAKE_BUILD_TYPE=Debug option
+local strict = {}
+
+---Enables strict mode.
+function strict.on() end
+
+---Disables strict mode.
+function strict.off() end
+
+return strict

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ For more information on using LSP refer to the [project's documentation](https:/
         + [x] `space` (partial)
         + [x] `stat` (partial)
         + [x] `tuple`
-    - [ ] `buffer`
+    - [x] `buffer`
     - [x] `clock`
     - [x] `console`
     - [ ] `config`
@@ -272,7 +272,7 @@ For more information on using LSP refer to the [project's documentation](https:/
     - [x] `datetime`
     - [x] `decimal`
     - [ ] `digest`
-    - [ ] `errno`
+    - [x] `errno`
     - [ ] `experimental.connpool`
     - [x] `fiber`
     - [x] `fio`

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ For more information on using LSP refer to the [project's documentation](https:/
     - [ ] `pickle`
     - [ ] `popen`
     - [ ] `socket`
-    - [ ] `strict`
+    - [x] `strict`
     - [x] `string`
     - [ ] `tarantool`
     - [x] `uri`


### PR DESCRIPTION
The first patch adds builtin `errno` module.
The second patch adds builtin `strict` module.
