### PR TITLE
Add builtin `csv` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Builtin `buffer` module definitions.
+* Builtin `csv` module definitions.
 * Builtin `errno` module definitions.
 * Builtin `strict` module definitions.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ For more information on using LSP refer to the [project's documentation](https:/
     - [x] `console`
     - [ ] `config`
     - [ ] `crypto`
-    - [ ] `csv`
+    - [x] `csv`
     - [x] `datetime`
     - [x] `decimal`
     - [ ] `digest`


### PR DESCRIPTION
This patch adds builtin `csv` module.

See Tarantool documentation
https://www.tarantool.io/en/doc/latest/reference/reference_lua/csv/