### PR TITLE
Add missing tuple type names and fix `box.space.*:format()` overloads

### DIFF
--- a/Library/box/space.lua
+++ b/Library/box/space.lua
@@ -1038,6 +1038,6 @@ function space_methods:frommap(tbl) end
 ---
 ---Formatting or reformatting a large space will cause occasional [yields](doc://app-yields) so that other requests will not be blocked. If the other requests cause an illegal situation such as a field value of the wrong type, the formatting or reformatting will fail.
 ---
----@param format box.space.format
----@overload fun(): box.space.format
-function space_methods:format(format) end
+---@param format? box.space.format
+---@return box.space.format
+function space_methods:format() end

--- a/Library/tarantool.lua
+++ b/Library/tarantool.lua
@@ -21,7 +21,7 @@
 ---| array # Tarantool arr
 
 ---@alias tuple_type scalar | compound
----@alias tuple_type_name 'unsigned' | 'string' | 'boolean' | 'number' | 'integer' | 'decimal' | 'varbinary' | 'uuid' | 'scalar' | 'array'
+---@alias tuple_type_name 'unsigned' | 'string' | 'boolean' | 'number' | 'double' | 'integer' | 'decimal' | 'varbinary' | 'uuid' | 'scalar' | 'array' | 'map' | 'any'
 
 ---@alias map table<string, tuple_type> Tarantool kv map, keys are always strings
 ---@alias array tuple_type[] Tarantool array


### PR DESCRIPTION
This patchset introduces a few fixes related to box format.

- Fix wrong overloads of `box.space.*:format()`.
- Add missing tuple types.
