### PR TITLE
Add changelog on tuple types and format overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Marked `vshard.router.call*` arguments and options optional.
+* Added missing `map`, `any`, `double` tuple type names.
+* Overloads of `box.space.*:format()` are now resolved properly.
 
 ## [0.1.1] - 14.04.25
 


### PR DESCRIPTION
This patch is a follow up of the previous two commits that adds missing
changelog entries.

* Commit e587e59 ("Add missing tuple types")
* Commit ac1d02 ("Fix wrong overloads of `box.space.*:format()")
