### PR TITLE
Add missing `format` arg to `box.space.*:format()`

### DIFF
--- a/Library/box/space.lua
+++ b/Library/box/space.lua
@@ -1040,4 +1040,4 @@ function space_methods:frommap(tbl) end
 ---
 ---@param format? box.space.format
 ---@return box.space.format
-function space_methods:format() end
+function space_methods:format(format) end


### PR DESCRIPTION
After commit ac1d02 ("Fix wrong overloads of `box.space.*:format()`")
`box.space.*:format()` definition was missing a `format` argument. This
patch adds it.
