### PR TITLE
Add new parameters to space field format

### DIFF
--- a/Library/box/space.lua
+++ b/Library/box/space.lua
@@ -342,10 +342,19 @@ function space_methods:bsize() end
 function space_methods:count(key, iterator) end
 
 
+---@alias box.space.foreign_key { space: string, field: string | { [string]: string } }
+---@alias box.space.collation "unicode" | "unicode_ci"
+---@alias box.space.nullable_action 'none'|'rollback'|'abort'|'fail'|'ignore'|'replace'|'default'
+
 ---@alias box.space.field_format {
 ---     name?: string,
 ---     type?: tuple_type_name,
----     is_nullable?: boolean
+---     is_nullable?: boolean,
+---     collation?: box.space.collation,
+---     constraint?: string | { [string]: string },
+---     foreign_key?: box.space.foreign_key | { [string]: box.space.foreign_key },
+---     default?: any,
+---     default_func?: string,
 ---} | [string, tuple_type_name]
 
 ---@alias box.space.format box.space.field_format[]


### PR DESCRIPTION
This patch adds new to box field format that can be used to configure
space format [^1].

This includes.
* `is_nullable`
* `foreign_key`
* `constraint`
* And other fields

Unfortunately, completions of this fields requires
https://github.com/EmmyLuaLs/emmylua-analyzer-rust/issues/502 to be
solved.

[^1] https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/format/
