### PR TITLE
Reuse the same format across tuples & spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Builtin `socket` module declarations.
 * Builtin `xlog` module declarations.
 * Builtin `box.iproto` submodule declarations.
+* `box.tuple.format` submodule.
+* Various `box.space.format` fields (e.g. `foreign_keys`, `constraint`).
 
 ### Fixed
 

--- a/Library/box/space.lua
+++ b/Library/box/space.lua
@@ -350,6 +350,7 @@ function space_methods:count(key, iterator) end
 ---     name?: string,
 ---     type?: tuple_type_name,
 ---     is_nullable?: boolean,
+---     nullable_action?: box.space.nullable_action,
 ---     collation?: box.space.collation,
 ---     constraint?: string | { [string]: string },
 ---     foreign_key?: box.space.foreign_key | { [string]: box.space.foreign_key },

--- a/Library/box/tuple.lua
+++ b/Library/box/tuple.lua
@@ -375,25 +375,18 @@ function box.tuple.is(object) end
 box.tuple.format = {}
 
 ---Tuple format.
+---
 ---@class box.tuple.format: userdata
 local tuple_format = {}
 
----@alias box.tuple.field_format {
----     name?: string,
----     type?: tuple_type_name,
----     is_nullable?: boolean,
----     nullable_action?: 'none'|'rollback'|'abort'|'fail'|'ignore'|'replace'|'default',
----     default?: string,
----     collation?: string,
----     constraint?: string | { [string]: string },
----     foreign_key?: { space: string, field: string },
----}
+---@alias box.tuple.field_format box.space.field_format
 
----`tuple_format:totable()` returns tuple_format as lua table.
+---Returns tuple format as a lua table.
+---
 ---@return box.tuple.field_format[]
 function tuple_format:totable() end
 
----Get a tuple_format iterator
+---Get a tuple_format iterator.
 ---
 ---In Lua, [`lua-table-value:pairs()`](https://www.lua.org/pil/7.3.html) is a method which returns: `function`, `lua-table-value`, `nil`.
 ---
@@ -402,9 +395,10 @@ function tuple_format:totable() end
 ---`tuple_format:ipairs()` is the same as `pairs()`, because tuple_format fields are always integers.
 ---
 ---@see box.tuple.format.ipairs
----@return fun() ctx, any box.tuple.field_format[], nil
+---@return fun(tbl: any): (integer, box.tuple.field_format)
 function tuple_format:pairs() end
 
+---@see box.tuple.format.pairs
 tuple_format.ipairs = tuple_format.pairs
 
 ---Get the format of a tuple.


### PR DESCRIPTION
This patch makes `box.tuple.format` reuse very similar
`box.space.format` class.
