### PR TITLE
Generate mkdocs from EmmyLua and delpoy to pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache 
+          restore-keys: |
+            mkdocs-material-
+      - run: cargo install
+      - name: Install emmylua_doc_cli
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: emmylua_doc_cli
+      - name: Generate docs from annotations
+        run: emmylua_doc_cli --input Library/ --output doc/
+      - name: Install Mkdocs Material
+        run: pip install mkdocs-material
+      - name: Deploy to GitHub pages
+        run: mkdocs gh-deploy --force
+        working-directory: doc/


### PR DESCRIPTION
This patch adds generation of the mkdocs documentation right from the
EmmyLua annotation. It uses emmylua_doc_cli [^1] tool. The result is
deployed automatically on GitHub Pages.

[^1] https://crates.io/crates/emmylua_doc_cli
