### PR TITLE
Fix extra cargo install in publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,6 @@ jobs:
           path: .cache 
           restore-keys: |
             mkdocs-material-
-      - run: cargo install
       - name: Install emmylua_doc_cli
         uses: baptiste0928/cargo-install@v3
         with:


### PR DESCRIPTION
This patch removes extra `cargo install` call in the GitHub pages Mkdocs
Material deploy CI introduced in  58e79605 ('Generate mkdocs from
EmmyLua and deploy to pages').
